### PR TITLE
Refactor: Use standard http.Handler interface for routes

### DIFF
--- a/app/router/handlers/health.go
+++ b/app/router/handlers/health.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/julienschmidt/httprouter"
 	"github.com/nickhstr/go-web-service/app/types"
 	"github.com/nickhstr/go-web-service/app/utils"
 )
@@ -16,7 +15,7 @@ type HealthInfo struct {
 }
 
 // Health reports general information about the service
-func Health(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+func Health(w http.ResponseWriter, r *http.Request) {
 	var (
 		res           []byte
 		err           error

--- a/app/router/handlers/index.go
+++ b/app/router/handlers/index.go
@@ -2,12 +2,10 @@ package handlers
 
 import (
 	"net/http"
-
-	"github.com/julienschmidt/httprouter"
 )
 
 // Index handles requests to the root route
-func Index(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+func Index(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/plain")
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte("Hello World!"))

--- a/app/router/handlers/index_test.go
+++ b/app/router/handlers/index_test.go
@@ -5,14 +5,12 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/julienschmidt/httprouter"
 	"github.com/nickhstr/go-web-service/app/router/handlers"
 	"github.com/nickhstr/go-web-service/app/utils/test"
 )
 
 func TestIndex(t *testing.T) {
 	respRec := httptest.NewRecorder()
-	router := httprouter.New()
 
 	tests := []struct {
 		method     string
@@ -27,13 +25,13 @@ func TestIndex(t *testing.T) {
 		for i, tt := range tests {
 			t.Logf("\tTest %d: When making a %s request to '%s'", i, tt.method, tt.url)
 			{
-				router.GET("/", handlers.Index)
+				handler := http.HandlerFunc(handlers.Index)
 				req, err := http.NewRequest(tt.method, tt.url, nil)
 				if err != nil {
 					t.Fatal(err)
 				}
 
-				router.ServeHTTP(respRec, req)
+				handler.ServeHTTP(respRec, req)
 
 				if status := respRec.Code; status != http.StatusOK {
 					t.Fatalf("\t%s\tThe status code should be %v", test.FAILURE, http.StatusOK)

--- a/app/router/router.go
+++ b/app/router/router.go
@@ -12,14 +12,20 @@ func New() http.Handler {
 	var router http.Handler
 	baseRouter := httprouter.New()
 
+	// Register routes with router
 	for _, route := range Routes {
-		baseRouter.Handle(route.Method, route.Path, route.Handler)
+		handler := http.HandlerFunc(route.Handler)
+
+		// Middleware can also be included here, on a per-route-basis
+
+		baseRouter.Handler(route.Method, route.Path, handler)
 	}
 
+	// Add middleware for all requsts
 	router = middleware.Compose(
 		baseRouter,
-		middleware.Transaction,
 		middleware.Logger,
+		middleware.Transaction,
 		middleware.Compression,
 	)
 

--- a/app/router/routes.go
+++ b/app/router/routes.go
@@ -1,7 +1,8 @@
 package router
 
 import (
-	"github.com/julienschmidt/httprouter"
+	"net/http"
+
 	"github.com/nickhstr/go-web-service/app/router/handlers"
 )
 
@@ -10,7 +11,7 @@ import (
 type Route struct {
 	Method  string
 	Path    string
-	Handler httprouter.Handle
+	Handler http.HandlerFunc
 }
 
 // Routes registers all routes for the router


### PR DESCRIPTION
By using the standard `http.Handler` interface for all route handlers, we gain a few things:
- Doesn't deviate from interfaces defined by the standard library
- Allows for easy refactoring if the router needs to be changed to use a different implementation
- Individual routes can make use of middleware, rather than just the router